### PR TITLE
Enable arbitrary gsutil subcommands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Takeru Sato <midium.size@gmail.com>
 
 COPY boto /root/.boto
 COPY run.sh /bin/run.sh
+COPY gsutil_wrapper.sh /bin/gsutil_wrapper
 COPY crontabs/root /root/crontabs/root
 
 #install deps and install gsutil
@@ -23,4 +24,4 @@ RUN apk add --update \
   && pip install gsutil \
   && apk del build-deps
 
-CMD /bin/run.sh && exec crond -f -c /root/crontabs
+ENTRYPOINT ["/bin/run.sh"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
 # gsutil-crontab
 
 [![Docker Repository on Quay](https://quay.io/repository/tkrs/gsutil-crontab/status "Docker Repository on Quay")](https://quay.io/repository/tkrs/gsutil-crontab)
+
+## Usage
+
+This container accepts arbitrary subcommands for `gsutil`. Execution flow of the container is as follows:
+
+1. Checks if an environment variable `DOWNLOAD_DIR` is declared and the directory doesn't exist, then create the directory.
+2. If the environment variable `SOURCE_PATH` is declared and not empty, then run `gsutil cp ${SOURCE_PATH} ${DOWNLOAD_DIR}`; otherwise pass all arguments to the `gsutil` command. This process is provided for backward compatibility and will be deprecated in the near future.
+3. Run crond in the foreground.
+
+For example, if you want to run `gsutil mv gs://example/foo/bar gs://example/foo/buzz`, run as follows:
+
+```
+$ docker run tkrs/gsutil-crontab mv gs://example/foo/bar gs://example/foo/buzz
+```
+
+If you want to run this container in a Kubernetes' Pod, give the instructions via the Pod's definition:
+
+```yaml
+containers:
+- name: gsutil
+  image: quay.io/tkrs/gsutil-crontab
+  args:
+  - mv
+  - gs://example/foo/bar
+  - gs://example/foo/buzz
+```

--- a/crontabs/root
+++ b/crontabs/root
@@ -1,1 +1,1 @@
-* 18 * * * /bin/run.sh
+* 18 * * * /bin/gsutil_wrapper

--- a/gsutil_wrapper.sh
+++ b/gsutil_wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if [ ! -z "${SOURCE_PATH}" ] && [ -d "${DOWNLOAD_DIR}" ]; then
+  exec gsutil cp "${SOURCE_PATH}" "${DOWNLOAD_DIR}"
+else
+  exec gsutil "$@"
+fi

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,19 @@
 #!/bin/sh
 
-mkdir -p ${DOWNLOAD_DIR}
-gsutil cp ${SOURCE_PATH} ${DOWNLOAD_DIR}
+
+prepare() {
+  if [ ! -z "${DOWNLOAD_DIR}" ] && [ ! -d "${DOWNLOAD_DIR}" ]; then
+    mkdir -p "${DOWNLOAD_DIR}"
+  fi
+}
+
+run_gsutil() {
+  /bin/gsutil_wrapper "$@"
+}
+
+main() {
+  prepare
+  run_gsutil "$@" && exec crond -f -c /root/crontabs
+}
+
+main "$@"


### PR DESCRIPTION
Also, this commit includes a workaround for current users -- if
both `$SOURCE_PATH` and `$DOWNLOAD_DIR` are specified, this container
behaves as it used to be.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tkrs/gsutil-crontab/5)
<!-- Reviewable:end -->
